### PR TITLE
Translation Completion information

### DIFF
--- a/src/Domain/Completion.php
+++ b/src/Domain/Completion.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Thinktomorrow\Squanto\Domain;
+
+class Completion
+{
+    public static function getPageCompletion($pageid)
+    {
+        $page = Page::find($pageid);
+        $total = $page->lines->count();
+        $results = collect([]);
+
+        foreach (config('squanto.locales') as $locale) {
+            $results->push(collect(Line::getValuesByLocaleAndPage($locale, $page->key))->count());
+        }
+
+        return $results->contains($total);
+    }
+
+    public static function getPageCompletionPerLocale($pageid, $locale)
+    {
+        $page   = Page::find($pageid);
+        $total  = $page->lines->where('locale', $locale)->count();
+
+        $results->push(collect(Line::getValuesByLocaleAndPage($locale, $page->key))->count());
+
+        return $results->contains($total);
+    }
+}

--- a/src/Domain/Completion.php
+++ b/src/Domain/Completion.php
@@ -4,19 +4,18 @@ namespace Thinktomorrow\Squanto\Domain;
 
 class Completion
 {
-    public static function getPageCompletion($pageid)
+    public static function check(Page $page)
     {
         foreach (config('squanto.locales') as $locale) {
-            if ((Integer)self::getPageCompletionPercentage($pageid, $locale) != 100) {
+            if ((Integer)self::asPercentage($page, $locale) != 100) {
                 return false;
             }
         }
         return true;
     }
 
-    public static function getPageCompletionPercentage($pageid, $locale)
+    public static function asPercentage(Page $page, $locale)
     {
-        $page   = Page::find($pageid);
         $total  = $page->lines->count();
 
         if ($total == 0) {

--- a/src/Domain/Completion.php
+++ b/src/Domain/Completion.php
@@ -6,24 +6,24 @@ class Completion
 {
     public static function getPageCompletion($pageid)
     {
-        $page = Page::find($pageid);
-        $total = $page->lines->count();
-        $results = collect([]);
-
         foreach (config('squanto.locales') as $locale) {
-            $results->push(collect(Line::getValuesByLocaleAndPage($locale, $page->key))->count());
+            if ((Integer)self::getPageCompletionPercentage($pageid, $locale) != 100) {
+                return false;
+            }
         }
-
-        return $results->contains($total);
+        return true;
     }
 
-    public static function getPageCompletionPerLocale($pageid, $locale)
+    public static function getPageCompletionPercentage($pageid, $locale)
     {
         $page   = Page::find($pageid);
-        $total  = $page->lines->where('locale', $locale)->count();
+        $total  = $page->lines->count();
 
-        $results->push(collect(Line::getValuesByLocaleAndPage($locale, $page->key))->count());
+        if ($total == 0) {
+            return 100;
+        }
 
-        return $results->contains($total);
+        $translated = collect(Line::getValuesByLocaleAndPage($locale, $page->key))->count();
+        return $translated / $total * 100;
     }
 }

--- a/src/Domain/Line.php
+++ b/src/Domain/Line.php
@@ -133,7 +133,7 @@ class Line extends Model
 
     public function areParagraphsAllowed()
     {
-        return (false !== strpos($this->allowed_html,'<p>'));
+        return (false !== strpos($this->allowed_html, '<p>'));
     }
 
     /**
@@ -158,8 +158,7 @@ class Line extends Model
             ->select(['squanto_lines.*','squanto_line_translations.locale','squanto_line_translations.value'])
             ->where('squanto_line_translations.locale', $locale);
 
-        if($pagekey)
-        {
+        if ($pagekey) {
             $lines = $lines
                 ->join('squanto_pages', 'squanto_lines.page_id', '=', 'squanto_pages.id')
                 ->where('squanto_pages.key', $pagekey);

--- a/src/Domain/Page.php
+++ b/src/Domain/Page.php
@@ -49,4 +49,14 @@ class Page extends Model
     {
         return $query->orderBy('sequence', 'ASC');
     }
+
+    public function isCompleted()
+    {
+        return Completion::check($this);
+    }
+
+    public function completionPercentage($locale)
+    {
+        return Completion::asPercentage($this, $locale);
+    }
 }

--- a/tests/unit/CompletionTest.php
+++ b/tests/unit/CompletionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Thinktomorrow\Squanto\Tests;
+
+use Thinktomorrow\Squanto\Domain\Line;
+use Thinktomorrow\Squanto\Domain\Page;
+use Thinktomorrow\Squanto\Domain\Completion;
+
+class CompletionTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_can_get_completion_stats_per_page()
+    {
+        $line = Line::make('foo.bar');
+        $page = Page::findByKey('foo');
+        $line->saveValue('nl', 'bazz');
+        $line->saveValue('en', 'bazz');
+        $line->saveValue('fr', 'bazz');
+        $this->assertTrue(Completion::getPageCompletion($page->id));
+
+        $line = Line::make('foo.vaz');
+        $page = Page::findByKey('foo');
+        $line->saveValue('fr', 'bazz');
+        Line::make('foo.va');
+        Line::make('foo.baz');
+        Line::make('foo.ba');
+
+        $this->assertFalse(Completion::getPageCompletion($page->id));
+    }
+
+    /** @test */
+    public function it_can_get_completion_stats_per_page_per_locale()
+    {
+        $line = Line::make('foo.bar');
+        $page = Page::findByKey('foo');
+        $line->saveValue('nl', 'bazz');
+        $line->saveValue('en', 'bazz');
+        $line->saveValue('fr', 'bazz');
+        $this->assertEquals(100, Completion::getPageCompletionPerLocale($page->id, 'en'));
+
+        $line = Line::make('foo.vaz');
+        $page = Page::findByKey('foo');
+        $line->saveValue('fr', 'bazz');
+        Line::make('foo.va');
+        Line::make('foo.baz');
+        Line::make('foo.ba');
+
+        $this->assertFalse(25, Completion::getPageCompletionPerLocale($page->id, 'fr'));
+    }
+}

--- a/tests/unit/CompletionTest.php
+++ b/tests/unit/CompletionTest.php
@@ -23,12 +23,15 @@ class CompletionTest extends TestCase
         $line->saveValue('fr', 'bazz');
         $this->assertTrue(Completion::getPageCompletion($page->id));
 
-        $line = Line::make('foo.vaz');
-        $page = Page::findByKey('foo');
+        $line = Line::make('fooo.vaz');
+        $page = Page::findByKey('fooo');
         $line->saveValue('fr', 'bazz');
-        Line::make('foo.va');
-        Line::make('foo.baz');
-        Line::make('foo.ba');
+        $line = Line::make('fooo.va');
+        $line->saveValue('fr', 'bazz');
+        $line = Line::make('fooo.baz');
+        $line->saveValue('fr', 'bazz');
+        $line = Line::make('fooo.ba');
+        $line->saveValue('fr', 'bazz');
 
         $this->assertFalse(Completion::getPageCompletion($page->id));
     }
@@ -41,15 +44,29 @@ class CompletionTest extends TestCase
         $line->saveValue('nl', 'bazz');
         $line->saveValue('en', 'bazz');
         $line->saveValue('fr', 'bazz');
-        $this->assertEquals(100, Completion::getPageCompletionPerLocale($page->id, 'en'));
+        $this->assertEquals(100.0, Completion::getPageCompletionPercentage($page->id, 'en'));
 
-        $line = Line::make('foo.vaz');
-        $page = Page::findByKey('foo');
+        $line = Line::make('fooo.vaz');
+        $page = Page::findByKey('fooo');
         $line->saveValue('fr', 'bazz');
-        Line::make('foo.va');
-        Line::make('foo.baz');
-        Line::make('foo.ba');
+        Line::make('fooo.va');
+        Line::make('fooo.baz');
+        Line::make('fooo.ba');
 
-        $this->assertFalse(25, Completion::getPageCompletionPerLocale($page->id, 'fr'));
+        $this->assertEquals(25.0, Completion::getPageCompletionPercentage($page->id, 'fr'));
+    }
+
+    /** @test */
+    public function it_returns_true_if_there_are_no_lines()
+    {
+        $page = Page::make('foo');
+        $this->assertTrue(Completion::getPageCompletion($page->id));
+    }
+
+    /** @test */
+    public function it_returns_100_if_there_are_no_lines()
+    {
+        $page = Page::make('foo');
+        $this->assertEquals(100, Completion::getPageCompletionPercentage($page->id, 'fr'));
     }
 }

--- a/tests/unit/LineTest.php
+++ b/tests/unit/LineTest.php
@@ -16,18 +16,18 @@ class LineTest extends TestCase
     public function it_can_store_a_translation()
     {
         $line = Line::make('foo.bar');
-        $line->saveValue('nl','bazz');
+        $line->saveValue('nl', 'bazz');
 
-        $this->assertEquals('bazz',$line->value);
+        $this->assertEquals('bazz', $line->value);
     }
 
     /** @test */
     public function it_can_retrieve_a_translation()
     {
-        Line::make('foo.bar')->saveValue('nl','bazz');
+        Line::make('foo.bar')->saveValue('nl', 'bazz');
 
-        $this->assertInstanceOf(Line::class,Line::findByKey('foo.bar'));
-        $this->assertEquals('bazz',Line::findByKey('foo.bar')->value);
+        $this->assertInstanceOf(Line::class, Line::findByKey('foo.bar'));
+        $this->assertEquals('bazz', Line::findByKey('foo.bar')->value);
     }
 
     /** @test */
@@ -36,8 +36,8 @@ class LineTest extends TestCase
         $line = Line::make('funky.fungi');
         $page = Page::findByKey('funky');
 
-        $this->assertInstanceOf(Page::class,$page);
-        $this->assertEquals($line->page_id,$page->id);
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertEquals($line->page_id, $page->id);
     }
 
     /** @test */
@@ -46,26 +46,25 @@ class LineTest extends TestCase
         $page = Page::make('bozo');
         $line = Line::make('bozo.clown');
 
-        $this->assertInstanceOf(Page::class,$page);
-        $this->assertEquals($line->page_id,$page->id);
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertEquals($line->page_id, $page->id);
     }
 
     /** @test */
     public function list_all_lines_per_locale()
     {
         Line::make('bozo.clown')
-            ->saveValue('nl','value-nl')
-            ->saveValue('fr','value-fr');
+            ->saveValue('nl', 'value-nl')
+            ->saveValue('fr', 'value-fr');
         Line::make('bozo.clown2')
-            ->saveValue('nl','value-nl-2');
+            ->saveValue('nl', 'value-nl-2');
 
         $lines = Line::getValuesByLocale('nl');
 
-        $this->assertCount(2,$lines);
-        $this->assertInternalType('array',$lines);
+        $this->assertCount(2, $lines);
+        $this->assertInternalType('array', $lines);
 
         $lines = Line::getValuesByLocale('fr');
-        $this->assertCount(1,$lines);
+        $this->assertCount(1, $lines);
     }
-
 }

--- a/tests/unit/PageKeyTest.php
+++ b/tests/unit/PageKeyTest.php
@@ -30,7 +30,7 @@ class PageKeyTest extends TestCase
     public function allow_expected_key_format()
     {
         $pageid = new PageKey('foo');
-        $this->assertEquals('foo',$pageid->get());
+        $this->assertEquals('foo', $pageid->get());
     }
 
     /** @test */
@@ -38,25 +38,25 @@ class PageKeyTest extends TestCase
     {
         // Page key is always removed for the label
         $pageid = new PageKey('foo');
-        $this->assertEquals('Foo',$pageid->getAsLabel());
+        $this->assertEquals('Foo', $pageid->getAsLabel());
     }
 
     public function it_can_create_the_page_key_from_linekey()
     {
         $pageid = PageKey::fromLineKeyString('foo.bar');
-        $this->assertEquals('foo',$pageid->get());
+        $this->assertEquals('foo', $pageid->get());
     }
 
     /** @test */
     public function it_can_check_if_linekey_comes_from_excluded_source()
     {
         $existing = config()->get('squanto.excluded_files');
-        config()->set('squanto.excluded_files',['foo']);
+        config()->set('squanto.excluded_files', ['foo']);
 
         $this->assertTrue(PageKey::fromString('foo')->isExcludedSource());
         $this->assertFalse(PageKey::fromString('foobar')->isExcludedSource());
 
-        config()->set('squanto.excluded_files',$existing);
+        config()->set('squanto.excluded_files', $existing);
 
         // Reset the static Pagekey property of the excluded files
         $lineKey = PageKey::fromString('foo');

--- a/tests/unit/PageTest.php
+++ b/tests/unit/PageTest.php
@@ -6,7 +6,7 @@ use Thinktomorrow\Squanto\Domain\Line;
 use Thinktomorrow\Squanto\Domain\Page;
 use Thinktomorrow\Squanto\Domain\Completion;
 
-class CompletionTest extends TestCase
+class PageTest extends TestCase
 {
     public function setUp()
     {
@@ -14,14 +14,14 @@ class CompletionTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_completion_stats_per_page()
+    public function it_can_get_completion_stats_on_page_object()
     {
         $line = Line::make('foo.bar');
         $page = Page::findByKey('foo');
         $line->saveValue('nl', 'bazz');
         $line->saveValue('en', 'bazz');
         $line->saveValue('fr', 'bazz');
-        $this->assertTrue(Completion::check($page));
+        $this->assertTrue($page->isCompleted());
 
         $line = Line::make('fooo.vaz');
         $page = Page::findByKey('fooo');
@@ -33,18 +33,18 @@ class CompletionTest extends TestCase
         $line = Line::make('fooo.ba');
         $line->saveValue('fr', 'bazz');
 
-        $this->assertFalse(Completion::check($page));
+        $this->assertFalse($page->isCompleted());
     }
 
     /** @test */
-    public function it_can_get_completion_stats_per_page_per_locale()
+    public function it_can_get_completion_stats_per_page_per_locale_on_page_object()
     {
         $line = Line::make('foo.bar');
         $page = Page::findByKey('foo');
         $line->saveValue('nl', 'bazz');
         $line->saveValue('en', 'bazz');
         $line->saveValue('fr', 'bazz');
-        $this->assertEquals(100.0, Completion::asPercentage($page, 'en'));
+        $this->assertEquals(100.0, $page->completionPercentage('en'));
 
         $line = Line::make('fooo.vaz');
         $page = Page::findByKey('fooo');
@@ -53,20 +53,20 @@ class CompletionTest extends TestCase
         Line::make('fooo.baz');
         Line::make('fooo.ba');
 
-        $this->assertEquals(25.0, Completion::asPercentage($page, 'fr'));
+        $this->assertEquals(25.0, $page->completionPercentage('fr'));
     }
 
     /** @test */
-    public function it_returns_true_if_there_are_no_lines()
+    public function it_returns_true_if_there_are_no_lines_on_page_object()
     {
         $page = Page::make('foo');
-        $this->assertTrue(Completion::check($page));
+        $this->assertTrue($page->isCompleted());
     }
 
     /** @test */
-    public function it_returns_100_if_there_are_no_lines()
+    public function it_returns_100_if_there_are_no_lines_on_page_object()
     {
         $page = Page::make('foo');
-        $this->assertEquals(100, Completion::asPercentage($page, 'fr'));
+        $this->assertEquals(100, $page->completionPercentage('fr'));
     }
 }

--- a/tests/unit/translators/SquantoTranslatorTest.php
+++ b/tests/unit/translators/SquantoTranslatorTest.php
@@ -19,7 +19,7 @@ class SquantoTranslatorTest extends TestCase
     /** @test */
     public function it_can_get_a_translation()
     {
-        $this->assertEquals('bazz',$this->translator->get('foo.bar'));
+        $this->assertEquals('bazz', $this->translator->get('foo.bar'));
     }
 
     /** @test */
@@ -27,19 +27,19 @@ class SquantoTranslatorTest extends TestCase
     {
         $foo = require __DIR__.'/../../stubs/cached/nl/foo.php';
 
-        $this->assertEquals($foo,$this->translator->get('foo'));
+        $this->assertEquals($foo, $this->translator->get('foo'));
     }
 
     /** @test */
     public function it_can_get_a_translation_with_placeholders()
     {
-        $this->assertEquals('hello Ben, welcome back',$this->translator->get('foo.hello',['name' => 'Ben']));
+        $this->assertEquals('hello Ben, welcome back', $this->translator->get('foo.hello', ['name' => 'Ben']));
     }
 
     /** @test */
     public function it_can_get_a_translation_for_specific_locale()
     {
-        $this->assertEquals('bash',$this->translator->get('foo.bar',[],'fr'));
+        $this->assertEquals('bash', $this->translator->get('foo.bar', [], 'fr'));
     }
 
     /** @test */
@@ -47,15 +47,15 @@ class SquantoTranslatorTest extends TestCase
     {
         app('translator')->setKeyAsDefault(false);
 
-        $this->assertEquals(null,$this->translator->get('unknown.key'));
+        $this->assertEquals(null, $this->translator->get('unknown.key'));
     }
 
     /** @test */
     public function it_can_get_a_fallback_translation()
     {
-        $this->assertEquals('bazzz',$this->translator->get('foo.bam',[],'fr',true));
-        $this->assertEquals('bazzz',$this->translator->get('foo.bam',[],'fr')); // Default is true
-        $this->assertEquals('foo.bam',$this->translator->get('foo.bam',[],'fr',false));
+        $this->assertEquals('bazzz', $this->translator->get('foo.bam', [], 'fr', true));
+        $this->assertEquals('bazzz', $this->translator->get('foo.bam', [], 'fr')); // Default is true
+        $this->assertEquals('foo.bam', $this->translator->get('foo.bam', [], 'fr', false));
     }
 
     /** @test */
@@ -63,7 +63,6 @@ class SquantoTranslatorTest extends TestCase
     {
         config()->set('squanto.excluded_files', ['foo']);
 
-        $this->assertEquals('bazz',$this->translator->get('foo.bar'));
+        $this->assertEquals('bazz', $this->translator->get('foo.bar'));
     }
-
 }


### PR DESCRIPTION
This PR provides a completion class through which we can get information about the completion of the translations.

There are two functions : 
Completion::getPageCompletion(1) returns true if the given page is completly translated.
Completion::getPageCompletionPercentage(1, 'nl') returns the completion percentage for the given page and the given locale.